### PR TITLE
Log error if response is not set

### DIFF
--- a/src/Slack.php
+++ b/src/Slack.php
@@ -39,7 +39,7 @@ class Slack
             Log::error($e->getMessage());
         }
 
-        if ($response->getStatusCode() != 200) {
+        if (!isset($response) || $response->getStatusCode() != 200) {
             Log::error(self::DEFAULT_ERROR_MESSAGE);
         }
     }


### PR DESCRIPTION
If `$response` is empty, `$response->getStatusCode()` causes
`Fatal error: Call to a member function getStatusCode() on a non-object`.
